### PR TITLE
Migrate to napari plugin engine 2

### DIFF
--- a/cellfinder_napari/napari.yaml
+++ b/cellfinder_napari/napari.yaml
@@ -1,0 +1,20 @@
+name: cellfinder-napari
+schema_version: 0.1.0
+contributions:
+  commands:
+  - id: cellfinder-napari.detect
+    title: Create Cell detection
+    python_name: cellfinder_napari.plugins:detect
+  - id: cellfinder-napari.train
+    title: Create Train network
+    python_name: cellfinder_napari.plugins:train
+  - id: cellfinder-napari.CurationWidget
+    title: Create Curation
+    python_name: cellfinder_napari.plugins:CurationWidget
+  widgets:
+  - command: cellfinder-napari.detect
+    display_name: Cell detection
+  - command: cellfinder-napari.train
+    display_name: Train network
+  - command: cellfinder-napari.CurationWidget
+    display_name: Curation

--- a/cellfinder_napari/plugins.py
+++ b/cellfinder_napari/plugins.py
@@ -1,10 +1,8 @@
 from cellfinder_napari.train import train
 from cellfinder_napari.detect import detect
 from cellfinder_napari.curation import CurationWidget
-from napari_plugin_engine import napari_hook_implementation
 
 
-@napari_hook_implementation
 def napari_experimental_provide_dock_widget():
     return [
         (detect, {"name": "Cell detection"}),

--- a/setup.py
+++ b/setup.py
@@ -59,5 +59,10 @@ setup(
         "Programming Language :: Python :: 3.9",
         "Operating System :: OS Independent",
     ],
-    entry_points={"napari.plugin": ["cellfinder = cellfinder_napari.plugins"]},
+    entry_points={
+             "napari.manifest": [
+                 "cellfinder-napari = cellfinder_napari:napari.yaml",
+             ],
+         },
+         package_data={"cellfinder_napari": ["napari.yaml"]},
 )


### PR DESCRIPTION
This is a result of following the instructions on the [npe2 migration guide](https://napari.org/plugins/stable/npe2_migration_guide.html). To the unexperienced eye manually testing, the results look reasonable (it looks the same as before) - but I would encourage the reviewer to at least test a standard workflow with it.

Fixing the `check-manifest` CI failure will be left to a separate PR (as it seems unrelated - was failing before too).