### PR TITLE
include missing YAML files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,8 @@
 include LICENSE
 include README.md
 include requirements.txt
+include .napari/config.yml
+include cellfinder_napari/napari.yaml
 
 recursive-include cellfinder_napari *.png
 


### PR DESCRIPTION
This fixes the CI failure and closes #49 .

My reasoning is that both these YAML files are useful to have in the source distribution, because
* `cellfinder_napari/napari.yaml`  is key to `napari` recognising the plugin.
* `.napari/config.yml` contains info for findability - this is specifically used by napari-hub, but other things may hook into it in the future.