### PR TITLE
Avoid running CI twice on pushes to a PR

### DIFF
--- a/.github/workflows/linting_checks.yml
+++ b/.github/workflows/linting_checks.yml
@@ -1,6 +1,10 @@
 name: checks
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -3,7 +3,11 @@
 
 name: tests
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   manifest:


### PR DESCRIPTION
Same as https://github.com/brainglobe/cellfinder-core/pull/33