### PR TITLE
Raise error box if no images specified

### DIFF
--- a/cellfinder_napari/detect.py
+++ b/cellfinder_napari/detect.py
@@ -17,6 +17,7 @@ from cellfinder_napari.thread_worker import run
 from cellfinder_napari.utils import (
     add_layers,
     brainglobe_logo,
+    display_error_box,
     html_label_widget,
 )
 
@@ -119,6 +120,11 @@ def detect() -> FunctionGui:
         reset_button :
             Reset parameters to default
         """
+        if signal_image is None or background_image is None:
+            display_error_box(
+                "Both signal and background images must be specified"
+            )
+            return
         data_inputs = DataInputs(
             signal_image.data,
             background_image.data,

--- a/cellfinder_napari/utils.py
+++ b/cellfinder_napari/utils.py
@@ -124,6 +124,13 @@ def display_info(widget, title, message):
     QMessageBox.information(widget, title, message, QMessageBox.Ok)
 
 
+def display_error_box(message):
+    msg = QMessageBox()
+    msg.setWindowTitle("Error")
+    msg.setText(message)
+    msg.exec()
+
+
 def display_question(widget, title, message):
     """
     Display a warning in a pop up that informs


### PR DESCRIPTION
This opens a GUI box that blocks `napari` with the following contents if at least one image is missing:
![Screenshot 2022-03-03 at 16 14 35](https://user-images.githubusercontent.com/6197628/156605411-b43d3f5b-c500-44b5-9128-979669022467.png)

