### PR TITLE
Add progress bar for cell detection

### DIFF
--- a/cellfinder_napari/thread_worker.py
+++ b/cellfinder_napari/thread_worker.py
@@ -1,4 +1,6 @@
-from cellfinder_core.main import main as cellfinder_run
+from typing import Generator
+
+from cellfinder_core.main import MainRunner
 from napari.qt.threading import thread_worker
 
 from cellfinder_napari.input_containers import (
@@ -15,11 +17,34 @@ def run(
     detection_inputs: DetectionInputs,
     classification_inputs: ClassificationInputs,
     misc_inputs: MiscInputs,
-) -> list:
-    """Runs cellfinder in a separate thread, to prevent GUI blocking."""
-    return cellfinder_run(
+) -> Generator:
+    """
+    Runs cellfinder in a separate thread, to prevent GUI blocking.
+
+    To give user feedback this function should yield a dictionary of attributes
+    to set on a `magicgui.widgets.ProgressBar`, e.g. to set the min and max
+    of the progress bar to 0, 10:
+
+        >>> yield {'min': 0, 'max': 10}
+    """
+
+    runner = MainRunner()
+    runner.run(
         **data_inputs.as_core_arguments(),
         **detection_inputs.as_core_arguments(),
         **classification_inputs.as_core_arguments(),
         **misc_inputs.as_core_arguments(),
     )
+
+    yield {"label": "Detecting"}
+    yield {"max": runner.detect_runner.nplanes}
+    planes_done = 0
+    while planes_done < runner.detect_runner.nplanes:
+        runner.detect_runner.planes_done_queue.get(block=True)
+        planes_done += 1
+        yield {"value": planes_done}
+
+    runner.detect_runner.join()
+    # Finished detection
+    points = runner.join()
+    return points


### PR DESCRIPTION
Fixes https://github.com/brainglobe/cellfinder-napari/issues/38. Depends on https://github.com/brainglobe/cellfinder-core/pull/36.

The approach I've taken is to manually add a `ProgressBar` to the GUI and then turn the main function into a `Generator` that yields dictionaries that tell the progress bar how to update itself. This gives us the flexibility of changing the progress bar label and length for the detection and classfication stages. So far only the detection stage is implemented.

