### PR TITLE
Add a progress bar for detection

### DIFF
--- a/cellfinder_napari/input_containers.py
+++ b/cellfinder_napari/input_containers.py
@@ -95,6 +95,10 @@ class DataInputs(InputContainer):
         del data_input_dict["voxel_size_x"]
         return data_input_dict
 
+    @property
+    def nplanes(self):
+        return len(self.signal_array)
+
     @classmethod
     def widget_representation(cls) -> dict:
         return dict(


### PR DESCRIPTION
This adds a progress bar to the cell detection widget. The main change is adding a custom `Worker` class to run `cellfinder-core` in a separate thread (this has replaced `@thread_worker`) and pass signals from the `cellfinder-core` thread to the `napari` thread to update the progress bar.

Depends on https://github.com/brainglobe/cellfinder-core/pull/37; to test locally you'll need to have the branch in https://github.com/brainglobe/cellfinder-core/pull/37 installed. Fixes #38 