### PR TITLE
Add scroll bars to widget

### DIFF
--- a/cellfinder_napari/detect.py
+++ b/cellfinder_napari/detect.py
@@ -6,6 +6,7 @@ import napari
 from cellfinder_core.classify.cube_generator import get_cube_depth_min_max
 from magicgui import magicgui
 from magicgui.widgets import FunctionGui, ProgressBar
+from qtpy.QtWidgets import QScrollArea
 
 from cellfinder_napari.input_containers import (
     ClassificationInputs,
@@ -217,5 +218,9 @@ def detect() -> FunctionGui:
 
     # Insert progress bar before the run and reset buttons
     widget.insert(-3, progress_bar)
+
+    scroll = QScrollArea()
+    scroll.setWidget(widget._widget._qwidget)
+    widget._widget._qwidget = scroll
 
     return widget


### PR DESCRIPTION
Currently there's no way to scroll the widget. For me at least this is a real pain, as the run button can end up dropping off the bottom of my screen and I can't test the widget (reported in https://github.com/brainglobe/cellfinder-napari/issues/24).

This PR adds scroll bars to the window. It does this using private API of `magicgui`, so I think we should really contribute a fix upstream to https://github.com/napari/magicgui/issues/380 to avoid this. But in the short term merging this would probably help us for testing? @brainglobe/ucl-rsdg any thoughts on whether to merge this and fix later, or leave it for now?