### PR TITLE
Add a basic widget test

### DIFF
--- a/cellfinder_napari/_tests/test_cellfinder_napari.py
+++ b/cellfinder_napari/_tests/test_cellfinder_napari.py
@@ -1,2 +1,0 @@
-def test_placeholder():
-    assert True

--- a/cellfinder_napari/tests/test_cellfinder_napari.py
+++ b/cellfinder_napari/tests/test_cellfinder_napari.py
@@ -1,0 +1,57 @@
+import glob
+import pathlib
+
+import napari
+import numpy as np
+import pytest
+from PIL import Image
+
+from cellfinder_napari.detect import detect
+
+test_data_dir = pathlib.Path(__file__) / ".." / ".." / ".." / "test_data"
+
+
+def load_stack(directory: pathlib.Path) -> np.ndarray:
+    """
+    Load a stack of .tif image files in the given directory.
+    """
+    tif_glob = str((directory / "*.tif").resolve())
+    ims = []
+    for f in sorted(glob.glob(tif_glob)):
+        ims.append(np.array(Image.open(f)))
+    return np.stack(ims, axis=0)
+
+
+# @pytest.fixture
+# def signal_image():
+#    return load_stack(test_data_dir / "crop_planes" / "ch0")
+
+
+# @pytest.fixture
+# def background_image():
+#    return load_stack(test_data_dir / "crop_planes" / "ch1")
+
+
+def test_detect_function(
+    make_napari_viewer,
+):  # , signal_image, background_image):
+    # Smoke test that running cell detection from the widget works
+
+    # Create viewer and add images
+    viewer = make_napari_viewer()
+    # signal_layer = viewer.add_image(signal_image, name='signal')
+    # background_layer = viewer.add_image(background_image, name='background')
+
+    # Create widget
+    widget = detect()
+    viewer.window.add_dock_widget(widget)
+
+    # Select images, and run detection
+    widget.reset_choices()
+    # widget.signal_image.value = signal_layer
+    # widget.background_image.value = background_layer
+
+    # TODO: work out how to run detection here whilst blocking execution.
+    # Currently calling widget() will start detection, but pytest will
+    # pass immediately because new processes are spawned to do the detection.
+    # Perhaps use https://pytest-qt.readthedocs.io/en/latest/signals.html ?

--- a/tox.ini
+++ b/tox.ini
@@ -27,7 +27,7 @@ passenv =
     PYVISTA_OFF_SCREEN
 deps =
     # Even though napari is a requirement for cellfinder-napari, we have to
-    # choose a specific framework to run the tests with
+    # ensure it is installed with the default Qt backend here.
     napari[pyqt]
     pytest  # https://docs.pytest.org/en/latest/contents.html
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/

--- a/tox.ini
+++ b/tox.ini
@@ -26,7 +26,12 @@ passenv =
     NUMPY_EXPERIMENTAL_ARRAY_FUNCTION
     PYVISTA_OFF_SCREEN
 deps =
+    # Even though napari is a requirement for cellfinder-napari, we have to
+    # choose a specific framework to run the tests with
+    napari[pyqt]
     pytest  # https://docs.pytest.org/en/latest/contents.html
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
+    pytest-qt
     pytest-xvfb ; sys_platform == 'linux'
-commands = pytest -v --color=yes --cov=cellfinder_napari --cov-report=xml
+commands =
+    pytest -v --color=yes --cov=cellfinder_napari --cov-report=xml


### PR DESCRIPTION
This adds a basic widget test. Currently it just creates a viewer and adds the widget to it, but that should be enough to smoke test the widget loads. Hopefully this will bump code coverage!

There are commented out sections that can be added later to:
- Add test data to the viewer (we need to decide on a test data location: https://github.com/brainglobe/cellfinder-napari/issues/45)
- Run detection

But I think those can be tackled separately, so am leaving them for now.