### PR TITLE
Add sample data as plugin

### DIFF
--- a/cellfinder_napari/napari.yaml
+++ b/cellfinder_napari/napari.yaml
@@ -11,6 +11,10 @@ contributions:
   - id: cellfinder-napari.CurationWidget
     title: Create Curation
     python_name: cellfinder_napari.plugins:CurationWidget
+  - id: cellfinder-napari.SampleData
+    title: Sample data
+    python_name: cellfinder_napari.sample_data:load_sample
+
   widgets:
   - command: cellfinder-napari.detect
     display_name: Cell detection
@@ -18,3 +22,8 @@ contributions:
     display_name: Train network
   - command: cellfinder-napari.CurationWidget
     display_name: Curation
+
+  sample_data:
+  - key: sample
+    display_name: Sample data
+    command: cellfinder-napari.SampleData

--- a/cellfinder_napari/sample_data.py
+++ b/cellfinder_napari/sample_data.py
@@ -1,0 +1,23 @@
+from typing import List
+
+import numpy as np
+import pooch
+from napari.types import LayerData
+from skimage.io import imread
+
+base_url = "https://raw.githubusercontent.com/brainglobe/cellfinder/master/tests/data/integration/detection/crop_planes"
+
+
+def load_sample() -> List[LayerData]:
+    layers = []
+    for ch, name in zip([0, 1], ["Signal", "Background"]):
+        data = []
+        for i in range(30):
+            url = f"{base_url}/ch{ch}/ch{ch}{str(i).zfill(4)}.tif"
+            file = pooch.retrieve(url=url, known_hash=None)
+            data.append(imread(file))
+
+        data = np.stack(data, axis=0)
+        layers.append((data, {"name": name}))
+
+    return layers

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ requirements = [
     "napari-ndtiffs",
     "brainglobe-napari-io",
     "cellfinder-core>=0.2.4",
+    "pooch>=1",  # For downloading sample data
 ]
 
 setup(


### PR DESCRIPTION
This provides a set of sample data to the "Open Sample" option in the `napari` "File" menu.  This introduces a new dependency, `pooch` (https://www.fatiando.org/pooch/latest/) for downloading and locally caching the files on the users hard drive.

When initially run this takes a little while (~10s of seconds) to download all the data, with no feedback in the napari window which isn't idea. Perhaps a solution to this is to show an info box when the download starts?

@adamltyson I've just taken the small dataset used in the `cellfinder` tests. Was this what you had in mind for the sample data? Or is there something else? It's trivial to change the URL to point somewhere else.

Fixes https://github.com/brainglobe/cellfinder-napari/issues/15