### PR TITLE
Add more docstrings and typing

### DIFF
--- a/cellfinder_napari/detect/detect.py
+++ b/cellfinder_napari/detect/detect.py
@@ -33,6 +33,9 @@ MIN_PLANES_ANALYSE = 0
 
 
 def detect() -> FunctionGui:
+    """
+    Create a detection plugin GUI.
+    """
     progress_bar = ProgressBar()
 
     @magicgui(
@@ -79,6 +82,7 @@ def detect() -> FunctionGui:
         reset_button,
     ) -> None:
         """
+        Run detection and classification.
 
         Parameters
         ----------
@@ -206,7 +210,10 @@ def detect() -> FunctionGui:
     widget.header.native.setOpenExternalLinks(True)
 
     @widget.reset_button.changed.connect
-    def restore_defaults() -> None:
+    def restore_defaults():
+        """
+        Restore default widget values.
+        """
         defaults = {
             **DataInputs.defaults(),
             **DetectionInputs.defaults(),

--- a/cellfinder_napari/detect/thread_worker.py
+++ b/cellfinder_napari/detect/thread_worker.py
@@ -50,10 +50,10 @@ class Worker(WorkerBase):
                 plane + 1,
             )
 
-        def detect_finished_callback(points: list):
+        def detect_finished_callback(points: list) -> None:
             self.npoints_detected = len(points)
 
-        def classify_callback(batch: int):
+        def classify_callback(batch: int) -> None:
             self.update_progress_bar.emit(
                 "Classifying cells",
                 # Default cellfinder-core batch size is 32. This seems to give

--- a/cellfinder_napari/detect/thread_worker.py
+++ b/cellfinder_napari/detect/thread_worker.py
@@ -1,3 +1,5 @@
+from typing import Iterable
+
 from cellfinder_core.main import main as cellfinder_run
 from napari.qt.threading import WorkerBase, WorkerBaseSignals, thread_worker
 from qtpy.QtCore import QObject, Signal
@@ -11,6 +13,10 @@ from .input_containers import (
 
 
 class MyWorkerSignals(WorkerBaseSignals):
+    """
+    Signals used by the Worker class below.
+    """
+
     # Emits (label, max, value) for the progress bar
     update_progress_bar = Signal(str, int, int)
 
@@ -36,8 +42,6 @@ class Worker(WorkerBase):
         self.classification_inputs = classification_inputs
         self.misc_inputs = misc_inputs
 
-        self.npoints_detected = None
-
     def work(self) -> list:
         def detect_callback(plane):
             self.update_progress_bar.emit(
@@ -46,10 +50,10 @@ class Worker(WorkerBase):
                 plane + 1,
             )
 
-        def detect_finished_callback(points):
+        def detect_finished_callback(points: list):
             self.npoints_detected = len(points)
 
-        def classify_callback(batch):
+        def classify_callback(batch: int):
             self.update_progress_bar.emit(
                 "Classifying cells",
                 # Default cellfinder-core batch size is 32. This seems to give

--- a/cellfinder_napari/sample_data.py
+++ b/cellfinder_napari/sample_data.py
@@ -9,6 +9,9 @@ base_url = "https://raw.githubusercontent.com/brainglobe/cellfinder/master/tests
 
 
 def load_sample() -> List[LayerData]:
+    """
+    Load some sample data.
+    """
     layers = []
     for ch, name in zip([0, 1], ["Signal", "Background"]):
         data = []

--- a/cellfinder_napari/utils.py
+++ b/cellfinder_napari/utils.py
@@ -1,7 +1,18 @@
+from typing import Callable, List, Optional, Tuple
+
+import napari
+import numpy as np
 import pandas as pd
 from imlib.cells.cells import Cell
 from pkg_resources import resource_filename
-from qtpy.QtWidgets import QComboBox, QLabel, QMessageBox, QPushButton
+from qtpy.QtWidgets import (
+    QComboBox,
+    QLabel,
+    QLayout,
+    QMessageBox,
+    QPushButton,
+    QWidget,
+)
 
 brainglobe_logo = resource_filename(
     "cellfinder_napari", "images/brainglobe.png"
@@ -9,13 +20,14 @@ brainglobe_logo = resource_filename(
 
 
 def html_label_widget(label: str, tag: str = "b") -> dict:
+    """Create a HMTL label for use with magicgui."""
     return dict(
         widget_type="Label",
         label=f"<{tag}>{label}</{tag}>",
     )
 
 
-def add_layers(points, viewer) -> None:
+def add_layers(points, viewer: napari.Viewer):
     """
     Adds classified cell candidates as two separate point layers to the napari viewer.
     """
@@ -44,14 +56,22 @@ def add_layers(points, viewer) -> None:
     )
 
 
-def cells_df_as_np(cells_df, new_order=[2, 1, 0], type_column="type"):
+def cells_df_as_np(
+    cells_df: pd.DataFrame,
+    new_order: List[int] = [2, 1, 0],
+    type_column: str = "type",
+) -> np.ndarray:
+    """
+    Convert a dataframe to an array, dropping *type_column* and re-ordering
+    the columns with *new_order*.
+    """
     cells_df = cells_df.drop(columns=[type_column])
     cells = cells_df[cells_df.columns[new_order]]
     cells = cells.to_numpy()
     return cells
 
 
-def cells_to_array(cells):
+def cells_to_array(cells: List[Cell]) -> Tuple[np.ndarray, np.ndarray]:
     df = pd.DataFrame([c.to_dict() for c in cells])
     points = cells_df_as_np(df[df["type"] == Cell.CELL])
     rejected = cells_df_as_np(df[df["type"] == Cell.UNKNOWN])
@@ -59,15 +79,18 @@ def cells_to_array(cells):
 
 
 def add_combobox(
-    layout,
-    label,
-    items,
-    row,
-    column=0,
-    label_stack=False,
+    layout: QLayout,
+    label: str,
+    items: List[str],
+    row: int,
+    column: int = 0,
+    label_stack: bool = False,
     callback=None,
-    width=150,
-):
+    width: int = 150,
+) -> Tuple[QComboBox, Optional[QLabel]]:
+    """
+    Add a selection box to *layout*.
+    """
     if label_stack:
         combobox_row = row + 1
         combobox_column = column
@@ -92,15 +115,18 @@ def add_combobox(
 
 
 def add_button(
-    label,
-    layout,
-    connected_function,
-    row,
-    column=0,
-    visibility=True,
-    minimum_width=0,
-    alignment="center",
+    label: str,
+    layout: QLayout,
+    connected_function: Callable,
+    row: int,
+    column: int = 0,
+    visibility: bool = True,
+    minimum_width: int = 0,
+    alignment: str = "center",
 ) -> QPushButton:
+    """
+    Add a button to *layout*.
+    """
     button = QPushButton(label)
     if alignment == "center":
         pass
@@ -116,7 +142,7 @@ def add_button(
     return button
 
 
-def display_info(widget, title, message):
+def display_info(widget: QWidget, title: str, message: str):
     """
     Display a warning in a pop up that informs
     about overwriting files
@@ -124,14 +150,17 @@ def display_info(widget, title, message):
     QMessageBox.information(widget, title, message, QMessageBox.Ok)
 
 
-def display_error_box(message):
+def display_error_box(message: str):
+    """
+    Display a pop up window with an error.
+    """
     msg = QMessageBox()
     msg.setWindowTitle("Error")
     msg.setText(message)
     msg.exec()
 
 
-def display_question(widget, title, message):
+def display_question(widget: QWidget, title: str, message: str) -> bool:
     """
     Display a warning in a pop up that informs
     about overwriting files

--- a/cellfinder_napari/utils.py
+++ b/cellfinder_napari/utils.py
@@ -20,14 +20,16 @@ brainglobe_logo = resource_filename(
 
 
 def html_label_widget(label: str, tag: str = "b") -> dict:
-    """Create a HMTL label for use with magicgui."""
+    """
+    Create a HMTL label for use with magicgui.
+    """
     return dict(
         widget_type="Label",
         label=f"<{tag}>{label}</{tag}>",
     )
 
 
-def add_layers(points, viewer: napari.Viewer):
+def add_layers(points, viewer: napari.Viewer) -> None:
     """
     Adds classified cell candidates as two separate point layers to the napari viewer.
     """
@@ -142,7 +144,7 @@ def add_button(
     return button
 
 
-def display_info(widget: QWidget, title: str, message: str):
+def display_info(widget: QWidget, title: str, message: str) -> None:
     """
     Display a warning in a pop up that informs
     about overwriting files
@@ -150,7 +152,7 @@ def display_info(widget: QWidget, title: str, message: str):
     QMessageBox.information(widget, title, message, QMessageBox.Ok)
 
 
-def display_error_box(message: str):
+def display_error_box(message: str) -> None:
     """
     Display a pop up window with an error.
     """
@@ -162,8 +164,7 @@ def display_error_box(message: str):
 
 def display_question(widget: QWidget, title: str, message: str) -> bool:
     """
-    Display a warning in a pop up that informs
-    about overwriting files
+    Display a warning in a pop up that informs about overwriting files.
     """
     message_reply = QMessageBox.question(
         widget,


### PR DESCRIPTION
This adds missing docstrings and typing for existing code that we've touched. Note that I haven't bothered touching `curation.py` and `train.py`, as I think this will be easier to do when @alessandrofelder tackles https://github.com/brainglobe/cellfinder-napari/issues/41.

xref https://github.com/brainglobe/cellfinder-napari/issues/46, but we should keep that issue open until curation and training have been refactored and have comprehensive docstrings.