### PR TITLE
Drop Python 3.7 tests, add 3.9 tests

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       matrix:
         # Run all supported Python versions on linux
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9"]
         os: [ubuntu-latest]
         # Include one windows and macos run
         include:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -12,14 +12,13 @@ jobs:
       - uses: brainglobe/actions/lint@v1
 
   manifest:
-    needs: linting
     name: Check Manifest
     runs-on: ubuntu-latest
     steps:
       - uses: brainglobe/actions/check_manifest@v1
 
   test:
-    needs: manifest
+    needs: [linting, manifest]
     name: ${{ matrix.platform }} py${{ matrix.python-version }}
     runs-on: ${{ matrix.platform }}
     strategy:

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -19,8 +19,8 @@ jobs:
 
   test:
     needs: [linting, manifest]
-    name: ${{ matrix.platform }} py${{ matrix.python-version }}
-    runs-on: ${{ matrix.platform }}
+    name: ${{ matrix.os }} py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         # Run all supported Python versions on linux

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -24,8 +24,15 @@ jobs:
     runs-on: ${{ matrix.platform }}
     strategy:
       matrix:
-        platform: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: [3.7, 3.8]
+        # Run all supported Python versions on linux
+        python-version: ["3.8", "3.9", "3.10"]
+        os: [ubuntu-latest]
+        # Include one windows and macos run
+        include:
+        - os: macos-latest
+          python-version: "3.9"
+        - os: windows-latest
+          python-version: "3.9"
 
     steps:
       # Setup pyqt libraries

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{37,38,39}-{linux,macos,windows}
+envlist = py{38,39,310}-{linux,macos,windows}
 
 [gh-actions]
 python =
-    3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 [gh-actions:env]
 PLATFORM =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39,310}-{linux,macos,windows}
+envlist = py{38,39,310}
 
 [gh-actions]
 python =
@@ -8,17 +8,7 @@ python =
     3.9: py39
     3.10: py310
 
-[gh-actions:env]
-PLATFORM =
-    ubuntu-latest: linux
-    macos-latest: macos
-    windows-latest: windows
-
 [testenv]
-platform =
-    macos: darwin
-    linux: linux
-    windows: win32
 passenv =
     CI
     GITHUB_ACTIONS

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 # For more information about tox, see https://tox.readthedocs.io/en/latest/
 [tox]
-envlist = py{38,39,310}
+envlist = py{38,39}
 
 [gh-actions]
 python =
     3.8: py38
     3.9: py39
-    3.10: py310
 
 [testenv]
 passenv =


### PR DESCRIPTION
This updates the CI to:

- Drop Python 3.7
- Add Python 3.9 (fixes https://github.com/brainglobe/cellfinder-napari/issues/83)
- Since this repository is pure Python, testing on windows/macOS/linux on all python version s (9 jobs) is a bit much, so only run one job each for windows/macos
- Run the linting and manifest jobs in parallel, to reduce the amount of time spent before starting to run the actual tests

There are issues with Python 3.10 tests that I don't understand, so I'm going to leave that for another issue/PR.