### PR TITLE
De-duplicate widget header

### DIFF
--- a/cellfinder_napari/detect/detect.py
+++ b/cellfinder_napari/detect/detect.py
@@ -12,7 +12,9 @@ from qtpy.QtWidgets import QScrollArea
 from cellfinder_napari.utils import (
     add_layers,
     brainglobe_logo,
+    header_label_widget,
     html_label_widget,
+    widget_header,
 )
 
 from .input_containers import (
@@ -39,9 +41,7 @@ def detect() -> FunctionGui:
     progress_bar = ProgressBar()
 
     @magicgui(
-        header=html_label_widget(
-            f'<img src="{brainglobe_logo}"width="100">cellfinder', "h1"
-        ),
+        header=header_label_widget,
         detection_label=html_label_widget("Cell detection", "h3"),
         **DataInputs.widget_representation(),
         **DetectionInputs.widget_representation(),
@@ -197,14 +197,7 @@ def detect() -> FunctionGui:
         worker.update_progress_bar.connect(update_progress_bar)
         worker.start()
 
-    widget.header.value = (
-        "<p>Efficient cell detection in large images.</p>"
-        '<p><a href="https://cellfinder.info" style="color:gray;">Website</a></p>'
-        '<p><a href="https://docs.brainglobe.info/cellfinder/napari-plugin" style="color:gray;">Documentation</a></p>'
-        '<p><a href="https://github.com/brainglobe/cellfinder-napari" style="color:gray;">Source</a></p>'
-        '<p><a href="https://www.biorxiv.org/content/10.1101/2020.10.21.348771v2" style="color:gray;">Citation</a></p>'
-        "<p><small>For help, hover the cursor over each parameter.</small>"
-    )
+    widget.header.value = widget_header
     widget.header.native.setOpenExternalLinks(True)
 
     @widget.reset_button.changed.connect

--- a/cellfinder_napari/train.py
+++ b/cellfinder_napari/train.py
@@ -4,7 +4,11 @@ from typing import Optional
 from magicgui import magicgui
 from napari.qt.threading import thread_worker
 
-from cellfinder_napari.utils import brainglobe_logo
+from cellfinder_napari.utils import (
+    header_label_widget,
+    html_label_widget,
+    widget_header,
+)
 
 
 def train():
@@ -34,10 +38,7 @@ def train():
     )
 
     @magicgui(
-        header=dict(
-            widget_type="Label",
-            label=f'<h1><img src="{brainglobe_logo}"width="100">cellfinder</h1>',
-        ),
+        header=header_label_widget,
         training_label=dict(
             widget_type="Label",
             label="<h3>Network training</h3>",
@@ -208,14 +209,7 @@ def train():
             )
             worker.start()
 
-    widget.header.value = (
-        "<p>Efficient cell detection in large images.</p>"
-        '<p><a href="https://cellfinder.info" style="color:gray;">Website</a></p>'
-        '<p><a href="https://docs.brainglobe.info/cellfinder/napari-plugin" style="color:gray;">Documentation</a></p>'
-        '<p><a href="https://github.com/brainglobe/cellfinder-napari" style="color:gray;">Source</a></p>'
-        '<p><a href="https://www.biorxiv.org/content/10.1101/2020.10.21.348771v2" style="color:gray;">Citation</a></p>'
-        "<p><small>For help, hover the cursor over each parameter.</small>"
-    )
+    widget.header.value = widget_header
     widget.header.native.setOpenExternalLinks(True)
 
     @widget.reset_button.changed.connect

--- a/cellfinder_napari/utils.py
+++ b/cellfinder_napari/utils.py
@@ -19,6 +19,16 @@ brainglobe_logo = resource_filename(
 )
 
 
+widget_header = """
+<p>Efficient cell detection in large images.</p>
+<p><a href="https://cellfinder.info" style="color:gray;">Website</a></p>
+<p><a href="https://docs.brainglobe.info/cellfinder-napari/introduction" style="color:gray;">Documentation</a></p>
+<p><a href="https://github.com/brainglobe/cellfinder-napari" style="color:gray;">Source</a></p>
+<p><a href="https://www.biorxiv.org/content/10.1101/2020.10.21.348771v2" style="color:gray;">Citation</a></p>
+<p><small>For help, hover the cursor over each parameter.</small>
+"""
+
+
 def html_label_widget(label: str, tag: str = "b") -> dict:
     """
     Create a HMTL label for use with magicgui.
@@ -27,6 +37,15 @@ def html_label_widget(label: str, tag: str = "b") -> dict:
         widget_type="Label",
         label=f"<{tag}>{label}</{tag}>",
     )
+
+
+header_label_widget = html_label_widget(
+    f"""
+<img src="{brainglobe_logo}"width="100">
+<p>cellfinder</p>
+""",
+    "h1",
+)
 
 
 def add_layers(points, viewer: napari.Viewer) -> None:


### PR DESCRIPTION
This de-duplicates definition of the header in detection/training widgets, and fixes the documentation link at the same time.