### PR TITLE
Add example to load napari and show detection sample data/widget

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -8,3 +8,4 @@ recursive-include cellfinder_napari *.png
 
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
+recursive-exclude examples *

--- a/cellfinder_napari/sample_data.py
+++ b/cellfinder_napari/sample_data.py
@@ -13,7 +13,7 @@ def load_sample() -> List[LayerData]:
     Load some sample data.
     """
     layers = []
-    for ch, name in zip([0, 1], ["Signal", "Background"]):
+    for ch, name in zip([1, 0], ["Background", "Signal"]):
         data = []
         for i in range(30):
             url = f"{base_url}/ch{ch}/ch{ch}{str(i).zfill(4)}.tif"

--- a/examples/show_detection_sample.py
+++ b/examples/show_detection_sample.py
@@ -1,0 +1,27 @@
+"""
+Load and show sample data
+=========================
+This example:
+- loads some sample data
+- adds the data to a napari viewer
+- loads the cellfinder-napari cell detection plugin
+- opens the napari viewer
+"""
+import napari
+
+from cellfinder_napari.sample_data import load_sample
+
+viewer = napari.Viewer()
+# Open plugin
+viewer.window.add_plugin_dock_widget(
+    plugin_name="cellfinder-napari", widget_name="Train network"
+)
+# Add sample data layers
+for layer in load_sample():
+    viewer.add_layer(napari.layers.Image(layer[0], **layer[1]))
+
+
+if __name__ == "__main__":
+    # The napari event loop needs to be run under here to allow the window
+    # to be spawned from a Python script
+    napari.run()

--- a/examples/show_detection_sample.py
+++ b/examples/show_detection_sample.py
@@ -14,7 +14,7 @@ from cellfinder_napari.sample_data import load_sample
 viewer = napari.Viewer()
 # Open plugin
 viewer.window.add_plugin_dock_widget(
-    plugin_name="cellfinder-napari", widget_name="Train network"
+    plugin_name="cellfinder-napari", widget_name="Cell detection"
 )
 # Add sample data layers
 for layer in load_sample():


### PR DESCRIPTION
This makes is super easy to spin up a `napari` window with sample data and the detection widget already loaded. I also changed the order of the signal/background data so that the signal data appears selected and on top when the napari window opens.