### PR TITLE
Propagate errors from the worker to main thread

### DIFF
--- a/cellfinder_napari/detect/detect.py
+++ b/cellfinder_napari/detect/detect.py
@@ -189,6 +189,12 @@ def detect() -> FunctionGui:
             lambda points: add_layers(points, viewer=viewer)
         )
 
+        # Make sure if the worker emits an error, it is propagated to this thread
+        def reraise(e):
+            raise Exception from e
+
+        worker.errored.connect(reraise)
+
         def update_progress_bar(label: str, max: int, value: int):
             progress_bar.label = label
             progress_bar.max = max


### PR DESCRIPTION
While debugging some code I noticed that `cellfinder-napari` can silently error if something goes wrong in the thread worker. This PR makes sure any exceptions are propagated from the worker thread through to the main thread, and therefore show up in the terminal and napari notification panel.