### PR TITLE
Give the user more feedback when running detection

### DIFF
--- a/cellfinder_napari/detect/thread_worker.py
+++ b/cellfinder_napari/detect/thread_worker.py
@@ -43,7 +43,9 @@ class Worker(WorkerBase):
         self.misc_inputs = misc_inputs
 
     def work(self) -> list:
-        def detect_callback(plane):
+        self.update_progress_bar.emit("Setting up detection...", 1, 0)
+
+        def detect_callback(plane: int) -> None:
             self.update_progress_bar.emit(
                 "Detecting cells",
                 self.data_inputs.nplanes,
@@ -52,6 +54,7 @@ class Worker(WorkerBase):
 
         def detect_finished_callback(points: list) -> None:
             self.npoints_detected = len(points)
+            self.update_progress_bar.emit("Setting up classification...", 1, 1)
 
         def classify_callback(batch: int) -> None:
             self.update_progress_bar.emit(
@@ -72,4 +75,5 @@ class Worker(WorkerBase):
             classify_callback=classify_callback,
             detect_finished_callback=detect_finished_callback,
         )
+        self.update_progress_bar.emit("Finished classification", 1, 1)
         return result

--- a/cellfinder_napari/detect/thread_worker.py
+++ b/cellfinder_napari/detect/thread_worker.py
@@ -54,7 +54,7 @@ class Worker(WorkerBase):
 
         def detect_finished_callback(points: list) -> None:
             self.npoints_detected = len(points)
-            self.update_progress_bar.emit("Setting up classification...", 1, 1)
+            self.update_progress_bar.emit("Setting up classification...", 1, 0)
 
         def classify_callback(batch: int) -> None:
             self.update_progress_bar.emit(


### PR DESCRIPTION
This partially addresses https://github.com/brainglobe/cellfinder-napari/issues/12, by providing messages that indicate to the user what is going on at all stages of cell detection and classification.