### PR TITLE
Fix widget scrolling with magicgui>=0.5

### DIFF
--- a/cellfinder_napari/detect/detect.py
+++ b/cellfinder_napari/detect/detect.py
@@ -219,7 +219,5 @@ def detect() -> FunctionGui:
     widget.insert(-3, progress_bar)
 
     scroll = QScrollArea()
-    scroll.setWidget(widget._widget._qwidget)
-    widget._widget._qwidget = scroll
-
-    return widget
+    scroll.setWidget(widget.native)
+    return scroll


### PR DESCRIPTION
`magicgui` 0.5 broke the scrollbars in `cellfinder-napari`. This was kind of unsurprising though, because the previous solution in `cellfinder-napari` was very hacky, and involved using private API in `magicgui` (always a bad idea...). This PR fixes that.

The fix is simple, and robust against future changes in `magicgui` - take the `QtWidget` magicgui provides, wrap it in a `ScrollArea` and return the `ScrollArea`.

Please could the reviewer manually check the scrollbar works with this PR and `magicgui==0.5.1`?