### PR TITLE
Expand training tests

### DIFF
--- a/cellfinder_napari/detect/__init__.py
+++ b/cellfinder_napari/detect/__init__.py
@@ -1,1 +1,1 @@
-from .detect import detect
+from .detect import detect_widget

--- a/cellfinder_napari/detect/detect.py
+++ b/cellfinder_napari/detect/detect.py
@@ -34,7 +34,7 @@ CUBE_DEPTH = 20
 MIN_PLANES_ANALYSE = 0
 
 
-def detect() -> FunctionGui:
+def detect_widget() -> FunctionGui:
     """
     Create a detection plugin GUI.
     """

--- a/cellfinder_napari/napari.yaml
+++ b/cellfinder_napari/napari.yaml
@@ -2,9 +2,9 @@ name: cellfinder-napari
 schema_version: 0.1.0
 contributions:
   commands:
-  - id: cellfinder-napari.detect
+  - id: cellfinder-napari.detect_widget
     title: Create Cell detection
-    python_name: cellfinder_napari.detect:detect
+    python_name: cellfinder_napari.detect:detect_widget
 
   - id: cellfinder-napari.training_widget
     title: Create Train network
@@ -19,7 +19,7 @@ contributions:
     python_name: cellfinder_napari.sample_data:load_sample
 
   widgets:
-  - command: cellfinder-napari.detect
+  - command: cellfinder-napari.detect_widget
     display_name: Cell detection
   - command: cellfinder-napari.training_widget
     display_name: Train network

--- a/cellfinder_napari/napari.yaml
+++ b/cellfinder_napari/napari.yaml
@@ -6,9 +6,9 @@ contributions:
     title: Create Cell detection
     python_name: cellfinder_napari.detect:detect
 
-  - id: cellfinder-napari.train
+  - id: cellfinder-napari.training_widget
     title: Create Train network
-    python_name: cellfinder_napari.train:train
+    python_name: cellfinder_napari.train:training_widget
 
   - id: cellfinder-napari.CurationWidget
     title: Create Curation
@@ -21,7 +21,7 @@ contributions:
   widgets:
   - command: cellfinder-napari.detect
     display_name: Cell detection
-  - command: cellfinder-napari.train
+  - command: cellfinder-napari.training_widget
     display_name: Train network
   - command: cellfinder-napari.CurationWidget
     display_name: Curation

--- a/cellfinder_napari/tests/test_curation.py
+++ b/cellfinder_napari/tests/test_curation.py
@@ -19,8 +19,9 @@ def curation_widget(make_napari_viewer):
     The viewer can be accessed using ``widget.viewer``.
     """
     viewer = make_napari_viewer()
-    widget = CurationWidget(viewer)
-    viewer.window.add_dock_widget(widget)
+    _, widget = viewer.window.add_plugin_dock_widget(
+        plugin_name="cellfinder-napari", widget_name="Curation"
+    )
     return widget
 
 
@@ -90,7 +91,7 @@ def test_cell_marking(curation_widget, tmp_path):
 
 
 @pytest.fixture
-def valid_curation_widget(make_napari_viewer):
+def valid_curation_widget(make_napari_viewer) -> CurationWidget:
     """
     Setup up a valid curation widget,
     complete with training data layers and points,
@@ -101,8 +102,11 @@ def valid_curation_widget(make_napari_viewer):
     for layer in image_layers:
         viewer.add_layer(napari.layers.Image(layer[0], **layer[1]))
 
-    curation_widget = CurationWidget(viewer)
-    viewer.window.add_dock_widget(curation_widget)
+    num_dw = len(viewer.window._dock_widgets)
+    _, curation_widget = viewer.window.add_plugin_dock_widget(
+        plugin_name="cellfinder-napari", widget_name="Curation"
+    )
+    assert len(viewer.window._dock_widgets) == num_dw + 1
 
     curation_widget.add_training_data()
     # Add a points layer to select points from

--- a/cellfinder_napari/tests/test_curation.py
+++ b/cellfinder_napari/tests/test_curation.py
@@ -150,7 +150,10 @@ def test_check_image_data_wrong_shape(valid_curation_widget):
         valid_curation_widget.signal_image_choice.setCurrentText("Wrong shape")
         valid_curation_widget.set_signal_image()
         valid_curation_widget.check_image_data_for_extraction()
-        assert show_info.called
+        show_info.assert_called_once_with(
+            "Please ensure both signal and background images are the "
+            "same size and shape."
+        )
 
 
 def test_check_image_data_missing_signal(valid_curation_widget):

--- a/cellfinder_napari/tests/test_detection.py
+++ b/cellfinder_napari/tests/test_detection.py
@@ -30,14 +30,6 @@ def get_detect_widget(make_napari_viewer):
     return widget
 
 
-def test_add_detect_widget(get_detect_widget):
-    """
-    Smoke test to check that adding detection widget works
-    """
-    widget = get_detect_widget
-    assert widget is not None
-
-
 def test_detect_worker():
     """
     Smoke test to check that the detection worker runs

--- a/cellfinder_napari/tests/test_detection.py
+++ b/cellfinder_napari/tests/test_detection.py
@@ -67,6 +67,16 @@ def test_run_detect(get_detect_widget, analyse_local):
         assert worker.called
 
 
+def test_run_detect_without_inputs():
+    """ """
+    with patch("cellfinder_napari.detect.detect.show_info") as show_info:
+        widget = (
+            detect_widget()
+        )  # won't have image layers, so should notice and show info
+        widget.call_button.clicked()
+        assert show_info.called
+
+
 def test_reset_defaults(get_detect_widget):
     """Smoke test that restore defaults doesn't error."""
     get_detect_widget.reset_button.clicked()

--- a/cellfinder_napari/tests/test_detection.py
+++ b/cellfinder_napari/tests/test_detection.py
@@ -24,7 +24,9 @@ def get_detect_widget(make_napari_viewer):
     widget = detect_widget()
     for layer in load_sample():
         viewer.add_layer(napari.layers.Image(layer[0], **layer[1]))
-    viewer.window.add_dock_widget(widget)
+    _, widget = viewer.window.add_plugin_dock_widget(
+        plugin_name="cellfinder-napari", widget_name="Cell detection"
+    )
     return widget
 
 

--- a/cellfinder_napari/tests/test_detection.py
+++ b/cellfinder_napari/tests/test_detection.py
@@ -1,12 +1,13 @@
 import glob
 import pathlib
+from unittest.mock import patch
 
 import napari
 import numpy as np
 import pytest
 from PIL import Image
 
-from cellfinder_napari.detect import detect
+from cellfinder_napari.detect import detect_widget
 from cellfinder_napari.detect.detect_containers import (
     ClassificationInputs,
     DataInputs,
@@ -17,13 +18,22 @@ from cellfinder_napari.detect.thread_worker import Worker
 from cellfinder_napari.sample_data import load_sample
 
 
-def test_add_detect_widget(make_napari_viewer):
+@pytest.fixture
+def get_detect_widget(make_napari_viewer):
+    viewer = make_napari_viewer()
+    widget = detect_widget()
+    for layer in load_sample():
+        viewer.add_layer(napari.layers.Image(layer[0], **layer[1]))
+    viewer.window.add_dock_widget(widget)
+    return widget
+
+
+def test_add_detect_widget(get_detect_widget):
     """
     Smoke test to check that adding detection widget works
     """
-    viewer = make_napari_viewer()
-    widget = detect()
-    viewer.window.add_dock_widget(widget)
+    widget = get_detect_widget
+    assert widget is not None
 
 
 def test_detect_worker():
@@ -41,3 +51,22 @@ def test_detect_worker():
         MiscInputs(start_plane=0, end_plane=1),
     )
     worker.work()
+
+
+@pytest.mark.parametrize(
+    argnames="analyse_local",
+    argvalues=[True, False],  # increase test coverage by covering both cases
+)
+def test_run_detect(get_detect_widget, analyse_local):
+    """
+    Test backend is called
+    """
+    with patch("cellfinder_napari.detect.detect.Worker") as worker:
+        get_detect_widget.analyse_local.value = analyse_local
+        get_detect_widget.call_button.clicked()
+        assert worker.called
+
+
+def test_reset_defaults(get_detect_widget):
+    """Smoke test that restore defaults doesn't error."""
+    get_detect_widget.reset_button.clicked()

--- a/cellfinder_napari/tests/test_train_containers.py
+++ b/cellfinder_napari/tests/test_train_containers.py
@@ -28,7 +28,8 @@ def test_core_args_passed(input_container):
     to the training backend actually is also expected by the backend
     """
     backend_signature = signature(run)
-    expected_kwargs_list = list(backend_signature.parameters.keys())
-    actual_kwargs_list = list(input_container.as_core_arguments().keys())
-    for key in actual_kwargs_list:
-        assert key in expected_kwargs_list
+    expected_kwargs_set = set(backend_signature.parameters.keys())
+    actual_kwargs_set = set(input_container.as_core_arguments().keys())
+    assert (
+        actual_kwargs_set <= expected_kwargs_set
+    )  # check all actual keywords are in expected (but not the other way around.)

--- a/cellfinder_napari/tests/test_train_containers.py
+++ b/cellfinder_napari/tests/test_train_containers.py
@@ -1,0 +1,34 @@
+from inspect import signature
+from typing import List
+
+import pytest
+from cellfinder_core.train.train_yml import run
+
+from cellfinder_napari.input_container import InputContainer
+from cellfinder_napari.train.train_containers import (
+    MiscTrainingInputs,
+    OptionalNetworkInputs,
+    OptionalTrainingInputs,
+    TrainingDataInputs,
+)
+
+
+@pytest.mark.parametrize(
+    argnames="input_container",
+    argvalues=[
+        MiscTrainingInputs(),
+        OptionalNetworkInputs(),
+        OptionalTrainingInputs(),
+        TrainingDataInputs(),
+    ],
+)
+def test_core_args_passed(input_container):
+    """
+    Check that any keyword argument that napari passes
+    to the training backend actually is also expected by the backend
+    """
+    backend_signature = signature(run)
+    expected_kwargs_list = list(backend_signature.parameters.keys())
+    actual_kwargs_list = list(input_container.as_core_arguments().keys())
+    for key in actual_kwargs_list:
+        assert key in expected_kwargs_list

--- a/cellfinder_napari/tests/test_training.py
+++ b/cellfinder_napari/tests/test_training.py
@@ -29,6 +29,10 @@ def test_add_training_widget(get_training_widget):
 
 
 def test_reset_to_defaults(get_training_widget):
+    """
+    A simple test for the reset button.
+    Checks widgets of a few different types are reset as expected.
+    """
     # change a few widgets to non-default values
     get_training_widget.yaml_files.value = ["file_1.yml", "file_2.yml"]
     get_training_widget.continue_training.value = True
@@ -47,6 +51,9 @@ def test_reset_to_defaults(get_training_widget):
 
 
 def test_run_with_no_yaml_files(get_training_widget):
+    """
+    Checks whether expected info message will be shown to user if they don't specify YAML file(s).
+    """
     with patch("cellfinder_napari.train.train.show_info") as show_info:
         get_training_widget.call_button.clicked()
         show_info.assert_called_once_with(
@@ -55,6 +62,9 @@ def test_run_with_no_yaml_files(get_training_widget):
 
 
 def test_run_with_virtual_yaml_files(get_training_widget):
+    """
+    Checks that training is run with expected set of parameters.
+    """
     with patch("cellfinder_napari.train.train.run_training") as run_training:
         # make default input valid - need yml files (they don't technically have to exist)
         virtual_yaml_files = (

--- a/cellfinder_napari/tests/test_training.py
+++ b/cellfinder_napari/tests/test_training.py
@@ -81,7 +81,7 @@ def test_run_with_virtual_yaml_files(get_training_widget):
         expected_misc_args = MiscTrainingInputs()
 
         # we expect the widget to make some changes to the defaults
-        # displayed before calling the training backed
+        # displayed before calling the training backend
         expected_training_args.yaml_files = virtual_yaml_files
         expected_network_args.trained_model = None
         expected_network_args.model_weights = None

--- a/cellfinder_napari/tests/test_training.py
+++ b/cellfinder_napari/tests/test_training.py
@@ -1,39 +1,84 @@
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
-from cellfinder_napari.train import train
+from cellfinder_napari.train.train import training_widget
+from cellfinder_napari.train.train_containers import (
+    MiscTrainingInputs,
+    OptionalNetworkInputs,
+    OptionalTrainingInputs,
+    TrainingDataInputs,
+)
 
 
 @pytest.fixture
-def training_widget(make_napari_viewer):
+def get_training_widget(make_napari_viewer):
     viewer = make_napari_viewer()
-    widget = train()
+    widget = training_widget()
     viewer.window.add_dock_widget(widget)
     return widget
 
 
-def test_add_training_widget(training_widget):
+def test_add_training_widget(get_training_widget):
     """
     Smoke test to check that adding training widget works
     """
-    widget = training_widget
+    widget = get_training_widget
     assert widget is not None
 
 
-def test_reset_to_defaults(training_widget):
+def test_reset_to_defaults(get_training_widget):
     # change a few widgets to non-default values
-    training_widget.yaml_files.value = ["file_1.yml", "file_2.yml"]
-    training_widget.continue_training.value = True
-    training_widget.epochs.value = 50
-    training_widget.test_fraction.value = 0.20
+    get_training_widget.yaml_files.value = ["file_1.yml", "file_2.yml"]
+    get_training_widget.continue_training.value = True
+    get_training_widget.epochs.value = 50
+    get_training_widget.test_fraction.value = 0.20
 
     # click reset button
-    training_widget.reset_button.clicked()
+    get_training_widget.reset_button.clicked()
 
     # check values have been reset
-    assert len(training_widget.yaml_files.value) == 1
-    assert training_widget.yaml_files.value[0] == Path.home()
-    assert not training_widget.continue_training.value
-    assert training_widget.epochs.value == 100
-    assert training_widget.test_fraction.value == 0.10
+    assert len(get_training_widget.yaml_files.value) == 1
+    assert get_training_widget.yaml_files.value[0] == Path.home()
+    assert not get_training_widget.continue_training.value
+    assert get_training_widget.epochs.value == 100
+    assert get_training_widget.test_fraction.value == 0.10
+
+
+def test_run_with_no_yaml_files(get_training_widget):
+    with patch("cellfinder_napari.train.train.show_info") as show_info:
+        get_training_widget.call_button.clicked()
+        show_info.assert_called_once_with(
+            "Please select a YAML file for training"
+        )
+
+
+def test_run_with_virtual_yaml_files(get_training_widget):
+    with patch("cellfinder_napari.train.train.run_training") as run_training:
+        # make default input valid - need yml files (they don't technically have to exist)
+        virtual_yaml_files = (
+            Path.home() / "file_1.yml",
+            Path.home() / "file_2.yml",
+        )
+        get_training_widget.yaml_files.value = virtual_yaml_files
+        get_training_widget.call_button.clicked()
+
+        # create expected arguments for run
+        expected_training_args = TrainingDataInputs()
+        expected_network_args = OptionalNetworkInputs()
+        expected_optional_training_args = OptionalTrainingInputs()
+        expected_misc_args = MiscTrainingInputs()
+
+        # we expect the widget to make some changes to the defaults
+        # displayed before calling the training backed
+        expected_training_args.yaml_files = virtual_yaml_files
+        expected_network_args.trained_model = None
+        expected_network_args.model_weights = None
+
+        run_training.assert_called_once_with(
+            expected_training_args,
+            expected_network_args,
+            expected_optional_training_args,
+            expected_misc_args,
+        )

--- a/cellfinder_napari/tests/test_training.py
+++ b/cellfinder_napari/tests/test_training.py
@@ -16,6 +16,9 @@ from cellfinder_napari.train.train_containers import (
 def get_training_widget(make_napari_viewer):
     viewer = make_napari_viewer()
     widget = training_widget()
+    _, widget = viewer.window.add_plugin_dock_widget(
+        plugin_name="cellfinder-napari", widget_name="Train network"
+    )
     viewer.window.add_dock_widget(widget)
     return widget
 

--- a/cellfinder_napari/tests/test_training.py
+++ b/cellfinder_napari/tests/test_training.py
@@ -1,10 +1,39 @@
+from pathlib import Path
+
+import pytest
+
 from cellfinder_napari.train import train
 
 
-def test_add_training_widget(make_napari_viewer):
-    """
-    Smoke test to check that adding training widget works
-    """
+@pytest.fixture
+def training_widget(make_napari_viewer):
     viewer = make_napari_viewer()
     widget = train()
     viewer.window.add_dock_widget(widget)
+    return widget
+
+
+def test_add_training_widget(training_widget):
+    """
+    Smoke test to check that adding training widget works
+    """
+    widget = training_widget
+    assert widget is not None
+
+
+def test_reset_to_defaults(training_widget):
+    # change a few widgets to non-default values
+    training_widget.yaml_files.value = ["file_1.yml", "file_2.yml"]
+    training_widget.continue_training.value = True
+    training_widget.epochs.value = 50
+    training_widget.test_fraction.value = 0.20
+
+    # click reset button
+    training_widget.reset_button.clicked()
+
+    # check values have been reset
+    assert len(training_widget.yaml_files.value) == 1
+    assert training_widget.yaml_files.value[0] == Path.home()
+    assert not training_widget.continue_training.value
+    assert training_widget.epochs.value == 100
+    assert training_widget.test_fraction.value == 0.10

--- a/cellfinder_napari/tests/test_training.py
+++ b/cellfinder_napari/tests/test_training.py
@@ -23,14 +23,6 @@ def get_training_widget(make_napari_viewer):
     return widget
 
 
-def test_add_training_widget(get_training_widget):
-    """
-    Smoke test to check that adding training widget works
-    """
-    widget = get_training_widget
-    assert widget is not None
-
-
 def test_reset_to_defaults(get_training_widget):
     """
     A simple test for the reset button.

--- a/cellfinder_napari/tests/test_utils.py
+++ b/cellfinder_napari/tests/test_utils.py
@@ -24,15 +24,8 @@ def test_html_label_widget():
     assert label_widget["label"] == "<h1>A nice label</h1>"
 
 
-@pytest.mark.parametrize(
-    argnames=["label", "label_stack"],
-    argvalues=[
-        ("a label", True),
-        ("a label", False),
-        (None, True),
-        (None, False),
-    ],
-)
+@pytest.mark.parametrize("label_stack", [True, False])
+@pytest.mark.parametrize("label", ["A label", None])
 def test_add_combobox(label, label_stack):
     """
     Smoke test for add_combobox for all conditional branches

--- a/cellfinder_napari/tests/test_utils.py
+++ b/cellfinder_napari/tests/test_utils.py
@@ -1,6 +1,8 @@
+import pytest
 from imlib.cells.cells import Cell
+from qtpy.QtWidgets import QGridLayout
 
-from ..utils import add_layers, html_label_widget
+from ..utils import add_button, add_combobox, add_layers, html_label_widget
 
 
 def test_add_layers(make_napari_viewer):
@@ -18,3 +20,45 @@ def test_html_label_widget():
     label_widget = html_label_widget("A nice label", tag="h1")
     assert label_widget["widget_type"] == "Label"
     assert label_widget["label"] == "<h1>A nice label</h1>"
+
+
+@pytest.mark.parametrize(
+    argnames=["label", "label_stack"],
+    argvalues=[
+        ("a label", True),
+        ("a label", False),
+        (None, True),
+        (None, False),
+    ],
+)
+def test_add_combobox(label, label_stack):
+    """
+    Smoke test for add_combobox for all conditional branches
+    """
+    layout = QGridLayout()
+    combobox = add_combobox(
+        layout,
+        row=0,
+        label=label,
+        items=["item 1", "item 2"],
+        label_stack=label_stack,
+    )
+    assert combobox is not None
+
+
+@pytest.mark.parametrize(
+    argnames="alignment", argvalues=["center", "left", "right"]
+)
+def test_add_button(alignment):
+    """
+    Smoke tests for add_button for all conditional branches
+    """
+    layout = QGridLayout()
+    button = add_button(
+        layout=layout,
+        connected_function=lambda: None,
+        label="A button",
+        row=0,
+        alignment=alignment,
+    )
+    assert button is not None

--- a/cellfinder_napari/tests/test_utils.py
+++ b/cellfinder_napari/tests/test_utils.py
@@ -12,7 +12,9 @@ def test_add_layers(make_napari_viewer):
         Cell(pos=[4, 5, 6], cell_type=Cell.UNKNOWN),
     ]
     viewer = make_napari_viewer()
-    add_layers(points, viewer)
+    n_layers = len(viewer.layers)
+    add_layers(points, viewer)  # adds a "detected" and a "rejected layer"
+    assert len(viewer.layers) == n_layers + 2
 
 
 def test_html_label_widget():

--- a/cellfinder_napari/tests/test_utils.py
+++ b/cellfinder_napari/tests/test_utils.py
@@ -1,0 +1,20 @@
+from imlib.cells.cells import Cell
+
+from ..utils import add_layers, html_label_widget
+
+
+def test_add_layers(make_napari_viewer):
+    """Smoke test for add_layers utility"""
+    points = [
+        Cell(pos=[1, 2, 3], cell_type=Cell.CELL),
+        Cell(pos=[4, 5, 6], cell_type=Cell.UNKNOWN),
+    ]
+    viewer = make_napari_viewer()
+    add_layers(points, viewer)
+
+
+def test_html_label_widget():
+    """Simple unit test for the HTML Label widget"""
+    label_widget = html_label_widget("A nice label", tag="h1")
+    assert label_widget["widget_type"] == "Label"
+    assert label_widget["label"] == "<h1>A nice label</h1>"

--- a/cellfinder_napari/train/__init__.py
+++ b/cellfinder_napari/train/__init__.py
@@ -1,1 +1,1 @@
-from .train import train
+from .train import training_widget

--- a/cellfinder_napari/train/train.py
+++ b/cellfinder_napari/train/train.py
@@ -1,4 +1,3 @@
-from lib2to3.pgen2.token import OP
 from pathlib import Path
 from typing import Optional
 
@@ -24,7 +23,24 @@ from .train_containers import (
 )
 
 
-def train() -> FunctionGui:
+@thread_worker
+def run_training(
+    training_data_inputs: TrainingDataInputs,
+    optional_network_inputs: OptionalNetworkInputs,
+    optional_training_inputs: OptionalTrainingInputs,
+    misc_training_inputs: MiscTrainingInputs,
+):
+    print("Running training")
+    train_yml(
+        **training_data_inputs.as_core_arguments(),
+        **optional_network_inputs.as_core_arguments(),
+        **optional_training_inputs.as_core_arguments(),
+        **misc_training_inputs.as_core_arguments(),
+    )
+    print("Finished!")
+
+
+def training_widget() -> FunctionGui:
     @magicgui(
         header=header_label_widget,
         training_label=html_label_widget("Network training", tag="h3"),
@@ -135,6 +151,7 @@ def train() -> FunctionGui:
         misc_training_inputs = MiscTrainingInputs(number_of_free_cpus)
 
         if yaml_files[0] == Path.home():  # type: ignore
+            print("invalid")
             show_info("Please select a YAML file for training")
         else:
             worker = run_training(
@@ -162,20 +179,3 @@ def train() -> FunctionGui:
                 getattr(widget, name).value = value
 
     return widget
-
-
-@thread_worker
-def run_training(
-    training_data_inputs: TrainingDataInputs,
-    optional_network_inputs: OptionalNetworkInputs,
-    optional_training_inputs: OptionalTrainingInputs,
-    misc_training_inputs: MiscTrainingInputs,
-):
-    print("Running training")
-    train_yml(
-        **training_data_inputs.as_core_arguments(),
-        **optional_network_inputs.as_core_arguments(),
-        **optional_training_inputs.as_core_arguments(),
-        **misc_training_inputs.as_core_arguments(),
-    )
-    print("Finished!")

--- a/cellfinder_napari/train/train.py
+++ b/cellfinder_napari/train/train.py
@@ -151,7 +151,6 @@ def training_widget() -> FunctionGui:
         misc_training_inputs = MiscTrainingInputs(number_of_free_cpus)
 
         if yaml_files[0] == Path.home():  # type: ignore
-            print("invalid")
             show_info("Please select a YAML file for training")
         else:
             worker = run_training(

--- a/cellfinder_napari/train/train_containers.py
+++ b/cellfinder_napari/train/train_containers.py
@@ -45,7 +45,7 @@ class OptionalNetworkInputs(InputContainer):
 
     trained_model: Optional[Path] = Path.home()
     model_weights: Optional[Path] = Path.home()
-    model_depth: str = list(models.keys())[0]
+    model_depth: str = list(models.keys())[2]
     pretrained_model: str = str(list(model_weight_urls.keys())[0])
 
     def as_core_arguments(self) -> dict:

--- a/cellfinder_napari/utils.py
+++ b/cellfinder_napari/utils.py
@@ -48,7 +48,7 @@ header_label_widget = html_label_widget(
 )
 
 
-def add_layers(points, viewer: napari.Viewer) -> None:
+def add_layers(points: List[Cell], viewer: napari.Viewer) -> None:
     """
     Adds classified cell candidates as two separate point layers to the napari viewer.
     """


### PR DESCRIPTION
## Description

**What is this PR**

- [ ] Bug fix
- [ ] Addition of a new feature
- [x] Other: Addition of tests

**Why is this PR needed?**

To increase test coverage ("Smoke tests") and add additional checks to the tests.

**What does this PR do?**

- Adds smoke tests to increase test coverage to 95%
- All files have coverage > 90% individually
- Some of the smoke tests are expanded to also include (some) checks
- Minor improvements:
   - fix default value of model depth in training to "50" (which is what it used to be before #41 changed it unintentionally!) 
   - ensure file name and function names don't overlap (to avoid confusion when patching in tests)
   - add type hint to `add_layers` utility

## References

Largely addresses #112 
Partially addresses #31 

## How has this PR been tested?

No existing functionality has changed (apart from one default value that was wrong).
The tests added as part of this PR increase the likelihood that current and future breakages will be picked up early, and tests pass.

## Is this a breaking change?

No.

## Does this PR require an update to the documentation?

If any features have changed, or have been added. Please explain how the documentation has been updated (and link to the associated PR). See [here](https://docs.cellfinder.info/for-developers/documentation) for details.

## Checklist:

- [x] The code has been tested locally
- [x] Tests have been added to cover all new functionality (unit & integration)
- [x] The documentation has been updated to reflect any changes
- [x] The code has been formatted with [pre-commit](https://pre-commit.com/)
