### PR TITLE
Updated curation to allow user defined cube size

### DIFF
--- a/cellfinder_napari/curation.py
+++ b/cellfinder_napari/curation.py
@@ -21,7 +21,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from .utils import add_button, add_combobox, display_question, add_spinbox
+from .utils import add_button, add_combobox, add_spinbox, display_question
 
 # Constants used throughout
 WINDOW_HEIGHT = 750
@@ -189,8 +189,8 @@ class CurationWidget(QWidget):
             self.load_data_layout,
             "Cube Height",
             self.set_cube_height_voxel_size,
-            6,          
-        )        
+            6,
+        )
         self.cube_depth_voxel_size, _ = add_spinbox(
             self.load_data_layout,
             "Cube Depth",
@@ -268,13 +268,15 @@ class CurationWidget(QWidget):
             self.training_data_non_cell_layer.metadata[
                 "point_type"
             ] = Cell.UNKNOWN
-            self.training_data_non_cell_layer.metadata["training_data"] = True 
+            self.training_data_non_cell_layer.metadata["training_data"] = True
 
-    def set_cube_width_voxel_size(self,):
-        '''
+    def set_cube_width_voxel_size(
+        self,
+    ):
+        """
         Sets the Cube Height in Voxels for Training Data
-        '''
-        value = self.cube_width_voxel_size.value()        
+        """
+        value = self.cube_width_voxel_size.value()
 
         if is_even(value):
             self.cube_width = value
@@ -283,13 +285,15 @@ class CurationWidget(QWidget):
                 "Value entered is invalid. "
                 "Please enter an even value between [2-50].",
             )
-            self.cube_width_voxel_size.setValue(50)   
+            self.cube_width_voxel_size.setValue(50)
 
-    def set_cube_height_voxel_size(self,):
-        '''
+    def set_cube_height_voxel_size(
+        self,
+    ):
+        """
         Sets the Cube Width in Voxels for Training Data
-        '''
-        value = self.cube_height_voxel_size.value()        
+        """
+        value = self.cube_height_voxel_size.value()
 
         if is_even(value):
             self.cube_height = value
@@ -299,12 +303,14 @@ class CurationWidget(QWidget):
                 "Please enter an even value between [2-50].",
             )
             self.cube_height_voxel_size.setValue(50)
-        
-    def set_cube_depth_voxel_size(self,):
-        '''
+
+    def set_cube_depth_voxel_size(
+        self,
+    ):
+        """
         Sets the Cube Depth in Voxels for Training Data
-        '''
-        value = self.cube_depth_voxel_size.value()        
+        """
+        value = self.cube_depth_voxel_size.value()
 
         if is_even(value):
             self.cube_depth = value
@@ -313,7 +319,7 @@ class CurationWidget(QWidget):
                 "Value entered is invalid. "
                 "Please enter an even value between [2-20].",
             )
-            self.cube_depth_voxel_size.setValue(20)           
+            self.cube_depth_voxel_size.setValue(20)
 
     def add_training_data(self):
         cell_name = "Training data (cells)"

--- a/cellfinder_napari/curation.py
+++ b/cellfinder_napari/curation.py
@@ -274,7 +274,7 @@ class CurationWidget(QWidget):
         self,
     ):
         """
-        Sets the Cube Height in Voxels for Training Data
+        Sets the Cube Width in Voxels for Training Data
         """
         value = self.cube_width_voxel_size.value()
 
@@ -283,7 +283,7 @@ class CurationWidget(QWidget):
         else:
             show_info(
                 "Value entered is invalid. "
-                "Please enter an even value between [2-50].",
+                "Please enter an even positive value.",
             )
             self.cube_width_voxel_size.setValue(50)
 
@@ -291,7 +291,7 @@ class CurationWidget(QWidget):
         self,
     ):
         """
-        Sets the Cube Width in Voxels for Training Data
+        Sets the Cube Height in Voxels for Training Data
         """
         value = self.cube_height_voxel_size.value()
 
@@ -300,7 +300,7 @@ class CurationWidget(QWidget):
         else:
             show_info(
                 "Value entered is invalid. "
-                "Please enter an even value between [2-50].",
+                "Please enter an even positive value.",
             )
             self.cube_height_voxel_size.setValue(50)
 
@@ -317,7 +317,7 @@ class CurationWidget(QWidget):
         else:
             show_info(
                 "Value entered is invalid. "
-                "Please enter an even value between [2-20].",
+                "Please enter an even positive value.",
             )
             self.cube_depth_voxel_size.setValue(20)
 

--- a/cellfinder_napari/curation.py
+++ b/cellfinder_napari/curation.py
@@ -6,6 +6,7 @@ import numpy as np
 import tifffile
 from brainglobe_napari_io.cellfinder.utils import convert_layer_to_cells
 from imlib.cells.cells import Cell
+from imlib.general.numerical import is_even
 from imlib.IO.yaml import save_yaml
 from magicgui.widgets import ProgressBar
 from napari.qt.threading import thread_worker
@@ -20,7 +21,7 @@ from qtpy.QtWidgets import (
     QWidget,
 )
 
-from .utils import add_button, add_combobox, display_question
+from .utils import add_button, add_combobox, display_question, add_spinbox
 
 # Constants used throughout
 WINDOW_HEIGHT = 750
@@ -178,30 +179,48 @@ class CurationWidget(QWidget):
             4,
             callback=self.set_training_data_non_cell,
         )
+        self.cube_width_voxel_size, _ = add_spinbox(
+            self.load_data_layout,
+            "Cube Width",
+            self.set_cube_width_voxel_size,
+            5,
+        )
+        self.cube_height_voxel_size, _ = add_spinbox(
+            self.load_data_layout,
+            "Cube Height",
+            self.set_cube_height_voxel_size,
+            6,          
+        )        
+        self.cube_depth_voxel_size, _ = add_spinbox(
+            self.load_data_layout,
+            "Cube Depth",
+            self.set_cube_depth_voxel_size,
+            7,
+        )
         self.mark_as_cell_button = add_button(
             "Mark as cell(s)",
             self.load_data_layout,
             self.mark_as_cell,
-            5,
+            8,
         )
         self.mark_as_non_cell_button = add_button(
             "Mark as non cell(s)",
             self.load_data_layout,
             self.mark_as_non_cell,
-            5,
+            8,
             column=1,
         )
         self.add_training_data_button = add_button(
             "Add training data layers",
             self.load_data_layout,
             self.add_training_data,
-            6,
+            9,
         )
         self.save_training_data_button = add_button(
             "Save training data",
             self.load_data_layout,
             self.save_training_data,
-            6,
+            9,
             column=1,
         )
         self.load_data_layout.setColumnMinimumWidth(0, COLUMN_WIDTH)
@@ -249,7 +268,52 @@ class CurationWidget(QWidget):
             self.training_data_non_cell_layer.metadata[
                 "point_type"
             ] = Cell.UNKNOWN
-            self.training_data_non_cell_layer.metadata["training_data"] = True
+            self.training_data_non_cell_layer.metadata["training_data"] = True 
+
+    def set_cube_width_voxel_size(self,):
+        '''
+        Sets the Cube Height in Voxels for Training Data
+        '''
+        value = self.cube_width_voxel_size.value()        
+
+        if is_even(value):
+            self.cube_width = value
+        else:
+            show_info(
+                "Value entered is invalid. "
+                "Please enter an even value between [2-50].",
+            )
+            self.cube_width_voxel_size.setValue(50)   
+
+    def set_cube_height_voxel_size(self,):
+        '''
+        Sets the Cube Width in Voxels for Training Data
+        '''
+        value = self.cube_height_voxel_size.value()        
+
+        if is_even(value):
+            self.cube_height = value
+        else:
+            show_info(
+                "Value entered is invalid. "
+                "Please enter an even value between [2-50].",
+            )
+            self.cube_height_voxel_size.setValue(50)
+        
+    def set_cube_depth_voxel_size(self,):
+        '''
+        Sets the Cube Depth in Voxels for Training Data
+        '''
+        value = self.cube_depth_voxel_size.value()        
+
+        if is_even(value):
+            self.cube_depth = value
+        else:
+            show_info(
+                "Value entered is invalid. "
+                "Please enter an even value between [2-20].",
+            )
+            self.cube_depth_voxel_size.setValue(20)           
 
     def add_training_data(self):
         cell_name = "Training data (cells)"

--- a/cellfinder_napari/tests/test_curation.py
+++ b/cellfinder_napari/tests/test_curation.py
@@ -38,6 +38,7 @@ def test_add_new_training_layers(curation_widget):
     assert layers[0].name == "Training data (cells)"
     assert layers[1].name == "Training data (non cells)"
 
+
 def test_set_cube_size(curation_widget):
     """
     Check setting cube size with even value works as expected.
@@ -53,7 +54,7 @@ def test_set_cube_size(curation_widget):
     widget.cube_width_voxel_size.setValue(40)
     widget.set_cube_width_voxel_size()
     assert widget.cube_width == 40
-    
+
     # Check setting value for cube height
     widget.cube_height_voxel_size.setValue(40)
     widget.set_cube_height_voxel_size()
@@ -69,7 +70,7 @@ def test_check_incorrect_cube_size(curation_widget):
     """
     Check for error if cube size is odd value.
     """
-    widget = curation_widget 
+    widget = curation_widget
 
     with patch("cellfinder_napari.curation.show_info") as show_info:
         widget.cube_width_voxel_size.setValue(41)
@@ -79,8 +80,7 @@ def test_check_incorrect_cube_size(curation_widget):
         widget.cube_depth_voxel_size.setValue(9)
         widget.set_cube_depth_voxel_size()
         show_info.assert_called_with(
-            "Value entered is invalid. "
-            "Please enter an even positive value."
+            "Value entered is invalid. " "Please enter an even positive value."
         )
 
 

--- a/cellfinder_napari/tests/test_curation.py
+++ b/cellfinder_napari/tests/test_curation.py
@@ -38,6 +38,51 @@ def test_add_new_training_layers(curation_widget):
     assert layers[0].name == "Training data (cells)"
     assert layers[1].name == "Training data (non cells)"
 
+def test_set_cube_size(curation_widget):
+    """
+    Check setting cube size with even value works as expected.
+    """
+    widget = curation_widget
+
+    # Check if default value is set
+    assert widget.cube_width == 50
+    assert widget.cube_height == 50
+    assert widget.cube_depth == 20
+
+    # Check setting value for cube width
+    widget.cube_width_voxel_size.setValue(40)
+    widget.set_cube_width_voxel_size()
+    assert widget.cube_width == 40
+    
+    # Check setting value for cube height
+    widget.cube_height_voxel_size.setValue(40)
+    widget.set_cube_height_voxel_size()
+    assert widget.cube_height == 40
+
+    # Check setting value for cube depth
+    widget.cube_depth_voxel_size.setValue(10)
+    widget.set_cube_depth_voxel_size()
+    assert widget.cube_depth == 10
+
+
+def test_check_incorrect_cube_size(curation_widget):
+    """
+    Check for error if cube size is odd value.
+    """
+    widget = curation_widget 
+
+    with patch("cellfinder_napari.curation.show_info") as show_info:
+        widget.cube_width_voxel_size.setValue(41)
+        widget.set_cube_width_voxel_size()
+        widget.cube_height_voxel_size.setValue(41)
+        widget.set_cube_height_voxel_size()
+        widget.cube_depth_voxel_size.setValue(9)
+        widget.set_cube_depth_voxel_size()
+        show_info.assert_called_with(
+            "Value entered is invalid. "
+            "Please enter an even positive value."
+        )
+
 
 def test_cell_marking(curation_widget, tmp_path):
     """

--- a/cellfinder_napari/tests/test_utils.py
+++ b/cellfinder_napari/tests/test_utils.py
@@ -2,7 +2,13 @@ import pytest
 from imlib.cells.cells import Cell
 from qtpy.QtWidgets import QGridLayout
 
-from ..utils import add_button, add_combobox, add_layers, html_label_widget
+from ..utils import (
+    add_button,
+    add_combobox,
+    add_layers,
+    add_spinbox,
+    html_label_widget,
+)
 
 
 def test_add_layers(make_napari_viewer):
@@ -39,6 +45,23 @@ def test_add_combobox(label, label_stack):
         label_stack=label_stack,
     )
     assert combobox is not None
+
+
+@pytest.mark.parametrize("label_stack", [True, False])
+@pytest.mark.parametrize("label", ["A label", None])
+def test_add_spinbox(label, label_stack):
+    """
+    Smoke tests for add_spinbox for all conditional branches
+    """
+    layout = QGridLayout()
+    spinbox = add_spinbox(
+        layout=layout,
+        connected_function=lambda: None,
+        label=label,
+        row=0,
+        label_stack=label_stack,
+    )
+    assert spinbox is not None
 
 
 @pytest.mark.parametrize(

--- a/cellfinder_napari/utils.py
+++ b/cellfinder_napari/utils.py
@@ -163,10 +163,10 @@ def add_spinbox(
     spinbox.setMaximumWidth = width
     if label == "Cube Depth":
         spinbox.setValue(20)
-        spinbox.setRange(1, 20)
+        spinbox.setRange(1, 1000000)
     else:
         spinbox.setValue(50)
-        spinbox.setRange(1, 50)
+        spinbox.setRange(1, 1000000)
     layout.addWidget(spinbox_label, row, column)
 
     spinbox.valueChanged.connect(connected_function)

--- a/cellfinder_napari/utils.py
+++ b/cellfinder_napari/utils.py
@@ -11,8 +11,8 @@ from qtpy.QtWidgets import (
     QLayout,
     QMessageBox,
     QPushButton,
-    QWidget,
     QSpinBox,
+    QWidget,
 )
 
 brainglobe_logo = resource_filename(
@@ -135,6 +135,7 @@ def add_combobox(
     layout.addWidget(combobox, combobox_row, combobox_column)
     return combobox, combobox_label
 
+
 def add_spinbox(
     layout: QLayout,
     label: str,
@@ -144,9 +145,9 @@ def add_spinbox(
     label_stack: bool = False,
     width: int = 150,
 ) -> QSpinBox:
-    '''
+    """
     Defines the properties for the SpinBox Widget.
-    '''
+    """
     if label_stack:
         spinbox_row = row + 1
         spinbox_column = column
@@ -171,6 +172,7 @@ def add_spinbox(
     spinbox.valueChanged.connect(connected_function)
     layout.addWidget(spinbox, spinbox_row, spinbox_column)
     return spinbox, spinbox_label
+
 
 def add_button(
     label: str,

--- a/cellfinder_napari/utils.py
+++ b/cellfinder_napari/utils.py
@@ -12,6 +12,7 @@ from qtpy.QtWidgets import (
     QMessageBox,
     QPushButton,
     QWidget,
+    QSpinBox,
 )
 
 brainglobe_logo = resource_filename(
@@ -134,6 +135,42 @@ def add_combobox(
     layout.addWidget(combobox, combobox_row, combobox_column)
     return combobox, combobox_label
 
+def add_spinbox(
+    layout: QLayout,
+    label: str,
+    connected_function: Callable,
+    row: int,
+    column: int = 0,
+    label_stack: bool = False,
+    width: int = 150,
+) -> QSpinBox:
+    '''
+    Defines the properties for the SpinBox Widget.
+    '''
+    if label_stack:
+        spinbox_row = row + 1
+        spinbox_column = column
+    else:
+        spinbox_row = row
+        spinbox_column = column + 1
+    spinbox = QSpinBox()
+    spinbox.setSingleStep(2)
+    spinbox.setMaximumWidth = width
+    spinbox.setKeyboardTracking(False)
+
+    spinbox_label = QLabel(label)
+    spinbox.setMaximumWidth = width
+    if label == "Cube Depth":
+        spinbox.setValue(20)
+        spinbox.setRange(1, 20)
+    else:
+        spinbox.setValue(50)
+        spinbox.setRange(1, 50)
+    layout.addWidget(spinbox_label, row, column)
+
+    spinbox.valueChanged.connect(connected_function)
+    layout.addWidget(spinbox, spinbox_row, spinbox_column)
+    return spinbox, spinbox_label
 
 def add_button(
     label: str,


### PR DESCRIPTION
Before submitting a pull request (PR), please read the [contributing guide](https://github.com/brainglobe/.github/blob/main/CONTRIBUTING.md).

## Description
Updated the napari plugin of cellfinder to allow user to redefine cube size and save it with the new cube sizes. The second commit should've been named "Fixed formatting issues".

**What is this PR**

This is an addition of a feature.

**Why is this PR needed?**

Currently the program only allows a specific cube size to be used for training and classification and this is the first step to allow user defined cube sizes with cellfinder. I will work on cellfinder-core and when ready, will submit a pull request in that repository.

## References

[#211 from cellfinder repository](https://github.com/brainglobe/cellfinder/issues/211)

## How has this PR been tested?

I tested to make sure napari accepts the new value for cube size and that the saved files are saved with the correct shape. In addition, based on the cellfinder documentation for cellfinder, the cube size can only be even values and will show in the conda terminal and napari if an odd value is input and reset back to the default values.

## Does this PR require an update to the documentation?

No documentation updates are needed as of yet. When full feature is released, documentation will need to be updated.

## Checklist:

- [ ] The code has been tested locally
- [ ] Tests have been added to cover all new functionality (unit & integration)
- [ ] The documentation has been updated to reflect any changes
- [ ] The code has been formatted with [pre-commit](https://pre-commit.com/)
