### PR TITLE
Prepare for retirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# This package has moved
+
+`cellfinder-napari` has merged with it's backend code and is now available as a [single package called `cellfinder`](https://github.com/brainglobe/cellfinder).
+We recommend you uninstall `cellfinder-napari` and instead use the functionality provided in the `cellfinder` package.
+
+These changes are part of our [wider restructuring](https://brainglobe.info/blog/version1/version_1_announcement.html) of the BrainGlobe suite of tools and analysis pipelines, which you can [keep up to date with on our blog](https://brainglobe.info/blog/index.html).
+
+---
+
 # cellfinder-napari
 
 [![License](https://img.shields.io/pypi/l/cellfinder-napari.svg?color=green)](https://github.com/napari/cellfinder-napari/raw/master/LICENSE)

--- a/cellfinder_napari/__init__.py
+++ b/cellfinder_napari/__init__.py
@@ -1,3 +1,10 @@
+from warnings import warn
+
+warn(
+    f"cellfinder-napari has merged with it's backend code and is now available as a combined package. To remain up to date, please install cellfinder: https://github.com/brainglobe/cellfinder",
+    DeprecationWarning,
+)
+
 __version__ = "0.0.20"
 __author__ = "Adam Tyson"
 __license__ = "GPL-3.0"

--- a/tox.ini
+++ b/tox.ini
@@ -25,4 +25,4 @@ deps =
     pytest-cov  # https://pytest-cov.readthedocs.io/en/latest/
     pytest-qt
 commands =
-    pytest -v --color=yes --cov=cellfinder_napari --cov-report=xml
+    pytest -v --color=yes --cov=cellfinder_napari --cov-report=xml -W ignore::DeprecationWarning


### PR DESCRIPTION
Marks the package for deprecation, as per https://github.com/brainglobe/BrainGlobe/issues/46.

Merging to be followed by a new version release, at `<v1.0.0`.

Rebase onto `main` recommended before merging, to catch any additional changes.