### PR TITLE
Remove napari trove classifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ authors = [
 ]
 classifiers = [
     "Development Status :: 4 - Beta",
-    "Framework :: napari",
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
     "Operating System :: OS Independent",


### PR DESCRIPTION
Trying this to see if we can remove the plugin from the napari plugin installation dialogue.